### PR TITLE
Update di connection.create

### DIFF
--- a/src/digitalIdentity-backend/pom.xml
+++ b/src/digitalIdentity-backend/pom.xml
@@ -39,6 +39,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<!-- <dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
@@ -47,7 +52,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
-    </dependency>
+    	</dependency>
     <dependency>
       <groupId>com.google.zxing</groupId>
 			<artifactId>core</artifactId>

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/model/User.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/model/User.java
@@ -32,6 +32,9 @@ public class User {
     @Column(length = 2048)
     private String invitationUrl;
 
+    @Column(length = 2048)
+    private String connectionId;
+
     public Integer getId() {
         return id;
     }
@@ -86,6 +89,14 @@ public class User {
 
     public void setInvitationUrl(String invitationUrl) {
         this.invitationUrl = invitationUrl;
+    }
+
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    public void setConnectionId(String connectionId) {
+        this.connectionId = connectionId;
     }
 
 }

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
@@ -18,11 +18,23 @@ public class DIConnectionService {
     @Autowired
     private UserRepository userRepository;
 
+    public void setUserRepository(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
     @Autowired
     private LissiApiService lissiApiService;
 
+    public void setLissiApiService(LissiApiService lissiApiService) {
+        this.lissiApiService = lissiApiService;
+    }
+
     @Autowired
     private MailService mailService;
+
+    public void setMailService(MailService mailService) {
+        this.mailService = mailService;
+    }
 
     /**
      * returns the json of a lissi-connection for given *id* as a paresed String.
@@ -61,17 +73,21 @@ public class DIConnectionService {
         user.setPassword("test");
 
         if (user_role != null && user_role != "") {
-            switch (user_role) {
+            switch (user_role.toLowerCase()) {
                 case "admin":
+                case "role_admin":
                     user.setUserRole(UserRole.fromString("ROLE_ADMIN"));
                     break;
                 case "employee":
+                case "role_employee":
                     user.setUserRole(UserRole.fromString("ROLE_EMPLOYEE"));
                     break;
                 case "hr_employee":
+                case "role_hr_employee":
                     user.setUserRole(UserRole.fromString("ROLE_HR_EMPLOYEE"));
                     break;
                 case "guest":
+                case "role_guest":
                     user.setUserRole(UserRole.fromString("ROLE_GUEST"));
                     break;
                 default:
@@ -95,7 +111,7 @@ public class DIConnectionService {
         }
 
         userRepository.save(user);
-        return ResponseEntity.status(200).body("\"Successful creation of the digital identity.\"");
+        return ResponseEntity.status(201).body("\"Successful creation of the digital identity.\"");
 
     }
 
@@ -159,7 +175,7 @@ public class DIConnectionService {
         Optional<User> user = userRepository.findById(id);
         if (user.isPresent()) {
             userRepository.delete(user.get());
-            //TODO remove connection in LissiAPI
+            // TODO remove connection in LissiAPI
             return ResponseEntity.status(200).body("success.");
         } else {
             return ResponseEntity.status(404).body("User with id " + id + " not found.");

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
@@ -94,9 +94,9 @@ public class DIConnectionService {
                     return ResponseEntity.status(500).body("\"User role not recognized.\"");
             }
         }
-
+        String invitationUrl;
         try {
-            String invitationUrl = lissiApiService.createConnectionInvitation(email);
+            invitationUrl = lissiApiService.createConnectionInvitation(email);
             user.setInvitationUrl(invitationUrl);
             String mailSuccess = mailService.sendInvitation(email, invitationUrl);
             if (!mailSuccess.equals("success")) {
@@ -109,6 +109,8 @@ public class DIConnectionService {
             return ResponseEntity.status(500)
                     .body("\"Invitation in Lissi could not be created! Error: " + e.toString() + "\"");
         }
+
+       
 
         userRepository.save(user);
         return ResponseEntity.status(201).body("\"Successful creation of the digital identity.\"");

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
@@ -107,7 +107,6 @@ public class DIConnectionService {
         // is a commit (ACID): atomicity, consistency, isolation, durability
         String email = user.getEmail();
         String password = user.getPassword();
-        String invitationUrl;
 
         // lissi invite
         CreateConnectionResponse lissiResponse;
@@ -118,7 +117,6 @@ public class DIConnectionService {
             return ResponseEntity.status(500)
                     .body("\" in Lissi could not be created!");
         }
-        user.setInvitationUrl(invitationUrl);
 
         // save user to local database
         user.setInvitationUrl(lissiResponse.getInvitationUrl());

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 
 import didentity.amos.digitalIdentity.enums.UserRole;
+import didentity.amos.digitalIdentity.messages.responses.CreateConnectionResponse;
 import didentity.amos.digitalIdentity.model.User;
 import didentity.amos.digitalIdentity.repository.UserRepository;
 
@@ -194,12 +195,20 @@ public class DIConnectionService {
     public ResponseEntity<String> remove(Integer id) {
         Optional<User> user = userRepository.findById(id);
         if (user.isPresent()) {
-            userRepository.delete(user.get());
-            // TODO remove connection in LissiAPI
-            return ResponseEntity.status(200).body("success.");
+            return remove(user.get());
         } else {
             return ResponseEntity.status(404).body("User with id " + id + " not found.");
         }
     }
 
+    public ResponseEntity<String> remove(User user) {
+        return remove(user, true, true);
+    }
+
+    public ResponseEntity<String> remove(User user, boolean removeCreds, boolean removeProofs) {
+        userRepository.delete(user);
+        // TODO:
+        // lissiApiService.removeConnection(user.getConnectionId(), removeCreds, removeProofs);
+        return ResponseEntity.status(200).body("Successfully removed connection.");
+    }
 }

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
@@ -110,8 +110,9 @@ public class DIConnectionService {
         String invitationUrl;
 
         // lissi invite
+        CreateConnectionResponse lissiResponse;
         try {
-            invitationUrl = lissiApiService.createConnectionInvitation(user.getEmail());
+            lissiResponse = lissiApiService.createConnectionInvitation(user.getEmail());
         } catch (RestClientException e) {
             e.printStackTrace();
             return ResponseEntity.status(500)
@@ -120,11 +121,13 @@ public class DIConnectionService {
         user.setInvitationUrl(invitationUrl);
 
         // save user to local database
+        user.setInvitationUrl(lissiResponse.getInvitationUrl());
+        user.setConnectionId(lissiResponse.getConnectionId());
         userRepository.save(user);
 
         // send invitation mail with qr Code
         // send invitation mail
-        if (mailService.sendInvitation(email, invitationUrl) == false ||
+        if (mailService.sendInvitation(email, user.getInvitationUrl()) == false ||
                 mailService.sendPassword(email, password) == false) {
             remove(user.getId());
             return ResponseEntity.status(500)

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/DIConnectionService.java
@@ -20,6 +20,10 @@ public class DIConnectionService {
     @Autowired
     private StrongPasswordService strongPasswordService;
 
+    public void setStrongPasswordService(StrongPasswordService strongPasswordService) {
+        this.strongPasswordService = strongPasswordService;
+    }
+
     @Autowired
     private UserRepository userRepository;
 
@@ -128,7 +132,7 @@ public class DIConnectionService {
         // send invitation mail
         if (mailService.sendInvitation(email, user.getInvitationUrl()) == false ||
                 mailService.sendPassword(email, password) == false) {
-            remove(user.getId());
+            remove(user);
             return ResponseEntity.status(500)
                     .body("\"Error during sending invitation mail process. Fully revoked creation.");
         }
@@ -208,7 +212,9 @@ public class DIConnectionService {
     public ResponseEntity<String> remove(User user, boolean removeCreds, boolean removeProofs) {
         userRepository.delete(user);
         // TODO:
-        // lissiApiService.removeConnection(user.getConnectionId(), removeCreds, removeProofs);
+        // lissiApiService.removeConnection(user.getConnectionId(), removeCreds,
+        // removeProofs);
         return ResponseEntity.status(200).body("Successfully removed connection.");
     }
+
 }

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/LissiApiService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/LissiApiService.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import didentity.amos.digitalIdentity.messages.responses.CreateConnectionResponse;
@@ -38,7 +39,7 @@ public class LissiApiService {
     /**
      * Creates new connection and returns invitation url.
      */
-    public String createConnectionInvitation(String alias) {
+    public String createConnectionInvitation(String alias) throws RestClientException{
         String url = baseUrl + "/ctrl/api/v1.0/connections/create-invitation";
 
         // build headers
@@ -59,6 +60,11 @@ public class LissiApiService {
         } else {
             return null;
         }
+    }
+
+    public String deleteConnectionInvitation(String alias) {
+        // TODO:
+        return "Deleted.";
     }
 
     /**
@@ -99,10 +105,10 @@ public class LissiApiService {
     @SuppressWarnings("unchecked") // TODO: if someone wants to bother with generic arrays, feel free :)
     public ResponseEntity<String> provideExistingSchemas(String activeState, String searchText) {
         String url = baseUrl + "/ctrl/api/v1.0/schemas";
-        
+
         activeState = activeState != null ? activeState : "";
         searchText = searchText != null ? searchText : "";
-        
+
         // build headers
         // build headers
         HttpHeaders headers = httpService.createHttpHeader(

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/LissiApiService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/LissiApiService.java
@@ -39,7 +39,7 @@ public class LissiApiService {
     /**
      * Creates new connection and returns invitation url.
      */
-    public String createConnectionInvitation(String alias) throws RestClientException{
+    public CreateConnectionResponse createConnectionInvitation(String alias) throws RestClientException {
         String url = baseUrl + "/ctrl/api/v1.0/connections/create-invitation";
 
         // build headers
@@ -56,7 +56,7 @@ public class LissiApiService {
 
         // check response status code
         if (response.getStatusCode() == HttpStatus.OK) {
-            return response.getBody().getInvitationUrl();
+            return response.getBody();
         } else {
             return null;
         }

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/MailService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/MailService.java
@@ -57,12 +57,12 @@ public class MailService {
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
             helper.setFrom(mailUsername);
             helper.setTo(to);
-            helper.setSubject("Initiales passwort für DIDentity");
+            helper.setSubject("Initiales passwort für DIdentity");
 
             String htmlText = "<img src='cid:logo' alt='logo' height='200'> " +
-                    "<h1>Hier ist ihr initiales Passwort für ihren Login in der DIDentity APP</h1>" +
+                    "<h1>Hier ist ihr initiales Passwort für ihren Login in der DIdentity App</h1>" +
                     "<h2>Passwort:" + strongPassword + " </h2>" +
-                    "<p>Geben sie ihr Passwort nicht wetier. Am besten ändern sie es direkt <a href=\""
+                    "<p>Geben sie ihr Passwort nicht weiter. Am besten ändern sie es direkt <a href=\""
                     + changePasswordUrl + "\">hier<a> </p>";
             helper.setText(htmlText, true);
             helper.addInline("logo", new ClassPathResource("img/logo.png"));

--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/MailService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/MailService.java
@@ -26,7 +26,7 @@ public class MailService {
     @Autowired
     private QrGeneratorService qrService;
 
-    public String sendInvitation(String to, String invitationLink) {
+    public boolean sendInvitation(String to, String invitationLink) {
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
@@ -46,12 +46,12 @@ public class MailService {
             mailSender.send(mimeMessage);
         } catch (Exception e) {
             e.printStackTrace();
-            return e.toString();
+            return false;
         }
-        return "success";
+        return true;
     }
 
-    public String sendPassword(String to, String strongPassword) {
+    public boolean sendPassword(String to, String strongPassword) {
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
@@ -69,8 +69,8 @@ public class MailService {
             mailSender.send(mimeMessage);
         } catch (Exception e) {
             e.printStackTrace();
-            return e.toString();
+            return false;
         }
-        return "success";
+        return true;
     }
 }

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
@@ -3,6 +3,9 @@ package didentity.amos.digitalIdentity.services;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,13 +63,14 @@ public class DIConnectionServiceTest {
 
     /**
      * /**
-     * Test: Create a new user within an empty database
+     * Test: Create a new user if email is not used
      * Expected: User should be saved to DB. HTTP.status(201)
      */
     @Test
     void itShouldCreateNewUserOnEmptyDB() {
         // given
         User expected = UserSamples.getSampleUser();
+        Mockito.when(userRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(null));
 
         // when
         ResponseEntity<String> response = connectionService.create(
@@ -84,17 +88,6 @@ public class DIConnectionServiceTest {
         User captured = userAgArgumentCaptor.getValue();
 
         assertEquals(expected.getEmail(), captured.getEmail());
-
-    }
-
-    /**
-     * Test: Create a new user within a populated database. Mail of the user is not
-     * taken.
-     * Expected: User should be saved to DB. Returns HTTP.status(201)
-     */
-    @Test
-    void itShouldCreateNewUserOnDB() {
-
     }
 
     /**
@@ -104,6 +97,21 @@ public class DIConnectionServiceTest {
      */
     @Test
     void itShouldNotCreateUserWithEqualMailsOnDB() {
+        // given
+        User user = UserSamples.getSampleUser();
+        Mockito.when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+
+        // when
+        ResponseEntity<String> response = connectionService.create(
+                user.getName(),
+                user.getSurname(),
+                user.getEmail(),
+                user.getUserRole().toString());
+
+        assertEquals(response.getStatusCode(), HttpStatus.valueOf(500));
+
+        // verify(lissiApiService.createConnectionInvitation(anyString())).
+        verify(lissiApiService, never()).createConnectionInvitation(anyString());
 
     }
 

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
@@ -43,23 +43,19 @@ public class DIConnectionServiceTest {
         connectionService.setUserRepository(userRepository);
         connectionService.setLissiApiService(lissiApiService);
         connectionService.setMailService(mailService);
+
+        defaultMocking();
     }
 
-    @BeforeEach
     void defaultMocking() {
         // lissi.createConnection will always return with "lissiUri"
-        Mockito.when(lissiApiService.createConnectionInvitation(anyString()))
-                .thenReturn("lissiUri");
+        Mockito.when(lissiApiService.createConnectionInvitation(anyString())).thenReturn("lissiUri");
 
         // mailService will always return success
-        Mockito.when(mailService.sendInvitation(anyString(), anyString()))
-                .thenReturn("success");
+        Mockito.when(mailService.sendInvitation(anyString(), anyString())).thenReturn("success");
 
         // Mock: userRepository.findByEmail returns null
-        Mockito.when(userRepository.findByEmail(anyString()))
-                .thenReturn(Optional.ofNullable(null));
-
-        System.err.println("build done");
+        Mockito.when(userRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(null));
 
     }
 
@@ -72,8 +68,8 @@ public class DIConnectionServiceTest {
     }
 
     /**
-     * /**
      * Test: Create a new user if email is not used
+     * 
      * Expected: User should be saved to DB. HTTP.status(201)
      */
     @Test
@@ -82,11 +78,8 @@ public class DIConnectionServiceTest {
         User expected = UserSamples.getSampleUser();
 
         // when
-        ResponseEntity<String> response = connectionService.create(
-                expected.getName(),
-                expected.getSurname(),
-                expected.getEmail(),
-                expected.getUserRole().toString());
+        ResponseEntity<String> response = connectionService.create(expected.getName(), expected.getSurname(),
+                expected.getEmail(), expected.getUserRole().toString());
 
         // then
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -104,9 +97,8 @@ public class DIConnectionServiceTest {
     }
 
     /**
-     * /**
-     * Test: Create a new user if email is not used
-     * Expected: Saved User should contain the to DB. HTTP.status(201)
+     * /** Test: Create a new user if email is not used Expected: Saved User should
+     * contain the to DB. HTTP.status(201)
      */
     @Test
     void itShouldSaveTheInvitationUrlWithUserOnEmptyDB() {
@@ -136,8 +128,8 @@ public class DIConnectionServiceTest {
 
     /**
      * Test: Create a new user with an email which is already present in a database
-     * mail comparison ignoring case
-     * Expected: User should not be saved to DB. Returns HTTP.status(500)
+     * mail comparison ignoring case Expected: User should not be saved to DB.
+     * Returns HTTP.status(500)
      */
     @Test
     void itShouldNotCreateUserWithEqualMailsOnDB() {
@@ -162,20 +154,16 @@ public class DIConnectionServiceTest {
 
     /**
      * Test: Create a new user a new user within an empty database. Mail of the user
-     * is not taken.
-     * Expected: calls lissiApiService.createConnectionInvitation with email as
-     * param
+     * is not taken. Expected: calls lissiApiService.createConnectionInvitation with
+     * email as param
      */
     @Test
     void itShouldCreateNewUserOnLissy() {
         User expected = UserSamples.getSampleUser();
 
         // when
-        ResponseEntity<String> response = connectionService.create(
-                expected.getName(),
-                expected.getSurname(),
-                expected.getEmail(),
-                expected.getUserRole().toString());
+        ResponseEntity<String> response = connectionService.create(expected.getName(), expected.getSurname(),
+                expected.getEmail(), expected.getUserRole().toString());
 
         // then
         assertEquals(response.getStatusCode(), HttpStatus.CREATED);
@@ -189,8 +177,8 @@ public class DIConnectionServiceTest {
     }
 
     /**
-     * Test: Create a new user a new user. Mail of the use is not taken.
-     * Expected: calls mailService. with valid params
+     * Test: Create a new user a new user. Mail of the use is not taken. Expected:
+     * calls mailService. with valid params
      */
     @Test
     void itShouldSendInvitationEmailAfterCreate() {
@@ -219,8 +207,8 @@ public class DIConnectionServiceTest {
 
     /**
      * Test: Create a new user a new user within an empty database. Mail of the user
-     * is not taken.
-     * Expected: User should not be saved to DB. Returns HTTP.status(500)
+     * is not taken. Expected: User should not be saved to DB. Returns
+     * HTTP.status(500)
      */
     @Test
     void itShouldNotCreateNewUserOnDatabaseIfLissiCreateConnectionFails() {
@@ -228,13 +216,10 @@ public class DIConnectionServiceTest {
         User user = UserSamples.getSampleUser();
         // Mock: overriding
         Mockito.when(lissiApiService.createConnectionInvitation(anyString()))
-                .thenThrow(new Exception("Error for Testing"));
+                .thenThrow(new IllegalStateException("Error for Testing"));
 
         // when
-        ResponseEntity<String> response = connectionService.create(
-                user.getName(),
-                user.getSurname(),
-                user.getEmail(),
+        ResponseEntity<String> response = connectionService.create(user.getName(), user.getSurname(), user.getEmail(),
                 user.getUserRole().toString());
 
         // then
@@ -245,22 +230,18 @@ public class DIConnectionServiceTest {
 
     /**
      * Test: Create a new user within a populated database. Mail of the user is not
-     * taken but sending the invitation to the user failed.
-     * Expected: User should not be saved to DB. Returns HTTP.status(500)
+     * taken but sending the invitation to the user failed. Expected: User should
+     * not be saved to DB. Returns HTTP.status(500)
      */
     @Test
     void itShouldNotCreateNewUserOnDatabaseIfSendingMailFails() {
         // given
         User user = UserSamples.getSampleUser();
         // Mock: overriding
-        Mockito.when(mailService.sendInvitation(anyString(), anyString()))
-                .thenReturn("failed");
+        Mockito.when(mailService.sendInvitation(anyString(), anyString())).thenReturn("failed");
 
         // when
-        ResponseEntity<String> response = connectionService.create(
-                user.getName(),
-                user.getSurname(),
-                user.getEmail(),
+        ResponseEntity<String> response = connectionService.create(user.getName(), user.getSurname(), user.getEmail(),
                 user.getUserRole().toString());
 
         // then
@@ -269,11 +250,7 @@ public class DIConnectionServiceTest {
     }
 
     /*
-     * ---
-     * Mocking for create
-     * ----
-     * userRepository.findByEmail
-     * userRepository.save
+     * --- Mocking for create ---- userRepository.findByEmail userRepository.save
      *
      * lissiApiService.createConnectionInvitation
      * 

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
@@ -87,7 +87,10 @@ public class DIConnectionServiceTest {
 
         User captured = userAgArgumentCaptor.getValue();
 
+        assertEquals(expected.getName(), captured.getName());
+        assertEquals(expected.getSurname(), captured.getSurname());
         assertEquals(expected.getEmail(), captured.getEmail());
+        assertEquals(expected.getUserRole(), captured.getUserRole());
     }
 
     /**
@@ -118,21 +121,60 @@ public class DIConnectionServiceTest {
     /**
      * Test: Create a new user a new user within an empty database. Mail of the user
      * is not taken.
-     * Expected: calls lissiApiService.createConnectionInvitation with valid params
+     * Expected: calls lissiApiService.createConnectionInvitation with email as
+     * param
      */
     @Test
     void itShouldCreateNewUserOnLissy() {
+        User expected = UserSamples.getSampleUser();
+        Mockito.when(userRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(null));
 
+        // when
+        ResponseEntity<String> response = connectionService.create(
+                expected.getName(),
+                expected.getSurname(),
+                expected.getEmail(),
+                expected.getUserRole().toString());
+
+        // then
+        assertEquals(response.getStatusCode(), HttpStatus.CREATED);
+        // track calls
+        ArgumentCaptor<String> userAgArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(lissiApiService).createConnectionInvitation(userAgArgumentCaptor.capture());
+
+        String captured = userAgArgumentCaptor.getValue();
+
+        assertEquals(expected.getEmail(), captured);
     }
 
     /**
-     * Test: Create a new user a new user within an empty database. Mail of the user
-     * is not taken.
-     * Expected: calls lissiApiService.createConnectionInvitation with valid params
+     * Test: Create a new user a new user. Mail of the use is not taken.
+     * Expected: calls mailService. with valid params
      */
     @Test
     void itShouldSendInvitationEmailAfterCreate() {
+        User expected = UserSamples.getSampleUser();
+        Mockito.when(userRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(null));
 
+        // when
+        ResponseEntity<String> response = connectionService.create(
+                expected.getName(),
+                expected.getSurname(),
+                expected.getEmail(),
+                expected.getUserRole().toString());
+
+        // then
+        assertEquals(response.getStatusCode(), HttpStatus.CREATED);
+        // track calls
+        ArgumentCaptor<String> userArgumentCaptor1 = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> userArgumentCaptor2 = ArgumentCaptor.forClass(String.class);
+        verify(mailService).sendInvitation(userArgumentCaptor1.capture(), userArgumentCaptor2.capture());
+
+        String captured1 = userArgumentCaptor1.getValue();
+        String captured2 = userArgumentCaptor2.getValue();
+
+        assertEquals(expected.getEmail(), captured1);
+        assertEquals("lissiUri", captured2);
     }
 
     /**

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/Services/DIConnectionServiceTest.java
@@ -1,0 +1,162 @@
+package didentity.amos.digitalIdentity.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import didentity.amos.digitalIdentity.model.User;
+import didentity.amos.digitalIdentity.repository.UserRepository;
+import didentity.amos.digitalIdentity.shared.samples.UserSamples;
+
+@DataJpaTest
+public class DIConnectionServiceTest {
+
+    private DIConnectionService connectionService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private LissiApiService lissiApiService;
+    @Mock
+    private MailService mailService;
+    private AutoCloseable autoCloseable;
+
+    @BeforeEach
+    void setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        connectionService = new DIConnectionService();
+        connectionService.setUserRepository(userRepository);
+        connectionService.setLissiApiService(lissiApiService);
+        connectionService.setMailService(mailService);
+    }
+
+    @BeforeEach
+    void mocking() {
+        // lissi.createConnection will always return with "lissiUri"
+        Mockito.when(lissiApiService.createConnectionInvitation(anyString())).thenReturn("lissiUri");
+
+        // mailService will always return success
+
+        Mockito.when(mailService.sendInvitation(anyString(), anyString()))
+                .thenReturn("success");
+
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        autoCloseable.close();
+    }
+
+    /**
+     * /**
+     * Test: Create a new user within an empty database
+     * Expected: User should be saved to DB. HTTP.status(201)
+     */
+    @Test
+    void itShouldCreateNewUserOnEmptyDB() {
+        // given
+        User expected = UserSamples.getSampleUser();
+
+        // when
+        ResponseEntity<String> response = connectionService.create(
+                expected.getName(),
+                expected.getSurname(),
+                expected.getEmail(),
+                expected.getUserRole().toString());
+
+        // then
+        assertEquals(response.getStatusCode(), HttpStatus.CREATED);
+        // track calls
+        ArgumentCaptor<User> userAgArgumentCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userAgArgumentCaptor.capture());
+
+        User captured = userAgArgumentCaptor.getValue();
+
+        assertEquals(expected.getEmail(), captured.getEmail());
+
+    }
+
+    /**
+     * Test: Create a new user within a populated database. Mail of the user is not
+     * taken.
+     * Expected: User should be saved to DB. Returns HTTP.status(201)
+     */
+    @Test
+    void itShouldCreateNewUserOnDB() {
+
+    }
+
+    /**
+     * Test: Create a new user with an email which is already present in a database
+     * mail comparison ignoring case
+     * Expected: User should not be saved to DB. Returns HTTP.status(500)
+     */
+    @Test
+    void itShouldNotCreateUserWithEqualMailsOnDB() {
+
+    }
+
+    /**
+     * Test: Create a new user a new user within an empty database. Mail of the user
+     * is not taken.
+     * Expected: calls lissiApiService.createConnectionInvitation with valid params
+     */
+    @Test
+    void itShouldCreateNewUserOnLissy() {
+
+    }
+
+    /**
+     * Test: Create a new user a new user within an empty database. Mail of the user
+     * is not taken.
+     * Expected: calls lissiApiService.createConnectionInvitation with valid params
+     */
+    @Test
+    void itShouldSendInvitationEmailAfterCreate() {
+
+    }
+
+    /**
+     * Test: Create a new user a new user within an empty database. Mail of the user
+     * is not taken.
+     * Expected: User should not be saved to DB. Returns HTTP.status(500)
+     */
+    @Test
+    void itShouldNotCreateNewUserOnDatabaseIfLissiCreateConnectionFails() {
+
+    }
+
+    /**
+     * Test: Create a new user within a populated database. Mail of the user is not
+     * taken.
+     * Expected: User should not be saved to DB. Returns HTTP.status(500)
+     */
+    @Test
+    void itShouldNotCreateNewUserOnDatabaseIfSendingMailFails() {
+
+    }
+
+    /*
+     * ---
+     * Mocking for create
+     * ----
+     * userRepository.findByEmail
+     * userRepository.save
+     *
+     * lissiApiService.createConnectionInvitation
+     * 
+     * mailService.sendInvitation
+     */
+
+}

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/repository/UserRepositoryTest.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/repository/UserRepositoryTest.java
@@ -1,4 +1,33 @@
 package didentity.amos.digitalIdentity.repository;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import didentity.amos.digitalIdentity.model.User;
+
 public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // test DataBase creation
+    @Test
+    void itShouldFindACreatedUser() {
+        // given
+        String email = "test@mail.org";
+        User user = new User();
+        user.setEmail(email);
+        userRepository.save(user);
+
+        // when
+        Optional<User> optional = userRepository.findByEmail(email);
+
+        // then
+        assertTrue(optional.isPresent());
+    }
+
 }

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/repository/UserRepositoryTest.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/repository/UserRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -13,6 +14,11 @@ public class UserRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
 
     // test DataBase creation
     @Test

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/shared/samples/CreateConnectionResponseSamples.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/shared/samples/CreateConnectionResponseSamples.java
@@ -1,0 +1,20 @@
+package didentity.amos.digitalIdentity.shared.samples;
+
+import didentity.amos.digitalIdentity.messages.responses.CreateConnectionResponse;
+import didentity.amos.digitalIdentity.messages.responses.Invitation;
+
+public class CreateConnectionResponseSamples {
+    public static CreateConnectionResponse getSample() {
+
+        CreateConnectionResponse response = new CreateConnectionResponse();
+
+        response.setAlias("alias");
+        response.setConnectionId("connectionId");
+        response.setInvitationUrl("invitationUrl");
+
+        Invitation invitation = InvitationSamples.getSample();
+        response.setInvitation(invitation);
+        // TODO:AdditionalProperties
+        return response;
+    }
+}

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/shared/samples/InvitationSamples.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/shared/samples/InvitationSamples.java
@@ -1,0 +1,31 @@
+package didentity.amos.digitalIdentity.shared.samples;
+
+import java.util.ArrayList;
+
+import didentity.amos.digitalIdentity.messages.responses.Invitation;
+
+public class InvitationSamples {
+
+    public static Invitation getSample() {
+        Invitation invitation = new Invitation();
+        invitation.setId("id");
+        invitation.setType("type");
+        invitation.setDid("did");
+        invitation.setImageUrl("imageUrl");
+        invitation.setLabel("label");
+
+        ArrayList<String> keys = new ArrayList<String>();
+        keys.add("key1");
+        keys.add("key2");
+        invitation.setRecipientKeys(keys);
+
+        ArrayList<String> routingKeys = new ArrayList<String>();
+        routingKeys.add("routeKey1");
+        invitation.setRoutingKeys(routingKeys);
+
+        invitation.setServiceEndpoint("serviceEndpoint");
+
+        return invitation;
+    }
+
+}

--- a/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/shared/samples/UserSamples.java
+++ b/src/digitalIdentity-backend/src/test/java/didentity/amos/digitalIdentity/shared/samples/UserSamples.java
@@ -1,0 +1,22 @@
+package didentity.amos.digitalIdentity.shared.samples;
+
+import didentity.amos.digitalIdentity.enums.UserRole;
+import didentity.amos.digitalIdentity.model.User;
+
+public class UserSamples {
+
+    public static User getSampleUser() {
+        return getSampleUser("achim@super.fix.com", "Achim", "Trautwein", "passwort123", UserRole.HR_EMPLOYEE);
+    }
+
+    public static User getSampleUser(String email, String name, String surname, String password, UserRole userRole) {
+        User user = new User();
+        user.setEmail(email);
+        user.setName(name);
+        user.setSurname(surname);
+        user.setPassword(password);
+        user.setUserRole(userRole);
+
+        return user;
+    }
+}

--- a/src/digitalIdentity-backend/src/test/resources/application.properties
+++ b/src/digitalIdentity-backend/src/test/resources/application.properties
@@ -1,0 +1,26 @@
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.url=jdbc:h2://mem:db;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=sa
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-aut=create-drop
+#spring.jpa.show-sql: true
+
+# Jakson properties: Serialization and Deserialization
+spring.jackson.default-property-inclusion=non_null
+
+
+# Mail Relay Settings:
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=<to be filled>
+spring.mail.password=<to be filled>
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# Lissi API 
+lissi.api.url=https://onboardingad.ddns.net
+# Authentification:
+lissi.auth.url= https://onboardingad.ddns.net/auth/realms/lissi-cloud/protocol/openid-connect/token
+lissi.auth.client.id= <to be filled>
+lissi.auth.client.secret= <to be filled>


### PR DESCRIPTION
updated DIConnection.craete:
- now uses PasswordService to create an secure initial password (and sends it via mail)
- added connectionID to model/user

adjusted tests to new behavior (tests for password still missing)

Wait for #146 to be merged before merging this one 🥇 