### PR TITLE
Improve error messages, add new error message service

### DIFF
--- a/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/AuthenticationService.java
+++ b/src/digitalIdentity-backend/src/main/java/didentity/amos/digitalIdentity/services/AuthenticationService.java
@@ -101,7 +101,7 @@ public class AuthenticationService {
 
         Optional<User> optional = userRepository.findByEmail(email);
         if (optional.isPresent() == false) {
-            return ResponseEntity.status(500).body("\"Internal Server Error.\"");
+            return ResponseEntity.status(500).body("\"Email not found.\"");
         }
         User user = optional.get();
         String old_password = user.getPassword();

--- a/src/digitalIdentity-frontend/src/app/pages/change-password-page/change-password-page.component.ts
+++ b/src/digitalIdentity-frontend/src/app/pages/change-password-page/change-password-page.component.ts
@@ -10,9 +10,9 @@ import {
 } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Params, Router } from '@angular/router';
-import { InformationPopUpComponent } from 'src/app/shared/pop-up/information-pop-up/information-pop-up.component';
 import { environment } from 'src/environments/environment';
 import { ActivatedRoute } from '@angular/router';
+import { ErrorMessageService } from 'src/app/services/error-message-service/error-message.service';
 
 @Component({
   selector: 'app-change-password-page',
@@ -29,7 +29,8 @@ export class ChangePasswordComponent implements OnInit {
     public http: HttpClient,
     public dialogRef: MatDialog,
     public router: Router,
-    public route: ActivatedRoute
+    public route: ActivatedRoute,
+    public errorMessageService: ErrorMessageService,
   ) {
     this.password = new FormControl('', [
       Validators.required,
@@ -95,10 +96,7 @@ export class ChangePasswordComponent implements OnInit {
               );
             }
           } else {
-            this.openDialog(
-              'Password change did not succeded!',
-              'Server response: ' + response.body
-            );
+            this.errorMessageService.openCustomErrorDialog('Server response: ' + response.body, 'Password change did not succeded!');
             if (isDevMode()) {
               console.log(
                 'Password change did not succeded! Server response: ' +
@@ -108,26 +106,14 @@ export class ChangePasswordComponent implements OnInit {
           }
         },
         error: (error) => {
-          this.openDialog(
-            'Password change did not succeded!',
-            'Server response: ' + error.error
-          );
+          this.errorMessageService.openCustomErrorDialog('Server response: ' + error.error, 'Password change did not succeded!');
           if (isDevMode()) {
             console.log(error);
           }
         },
       });
   }
-  //opens a PopUp window of class InformationPopUpComponent
-  openDialog(header: string, text: string) {
-    console.log('open');
-    this.dialogRef.open(InformationPopUpComponent, {
-      data: {
-        header: header,
-        text: text,
-      },
-    });
-  }
+
   // handling errors by validators
   matchingError(): boolean {
     return this.formGroup.errors != null && this.formGroup.errors['noMatch'];

--- a/src/digitalIdentity-frontend/src/app/pages/credential/create-credDef/create-cred-def.component.ts
+++ b/src/digitalIdentity-frontend/src/app/pages/credential/create-credDef/create-cred-def.component.ts
@@ -237,11 +237,6 @@ export class CreateCredDefComponent
           });
         } else {
           this.isSuccessData = false;
-          this.openDialog(
-            'Creation of credential definition not successful!',
-            'Server response: ' + response.body,
-            this.isSuccessData
-          );
         }
       })
       .catch((response) => {
@@ -252,11 +247,6 @@ export class CreateCredDefComponent
           console.log('error');
           console.log(response);
         }
-        this.openDialog(
-          'Error during creation!',
-          'Server response: ' + response,
-          this.isSuccessData
-        );
       });
   }
 
@@ -289,15 +279,5 @@ export class CreateCredDefComponent
           console.log(response);
         }
       });
-  }
-
-  openDialog(header: string, text: string, isSuccessData: boolean) {
-    this.dialogRef.open(InformationPopUpComponent, {
-      data: {
-        header: header,
-        text: text,
-        isSuccessData: this.isSuccessData
-      },
-    });
   }
 }

--- a/src/digitalIdentity-frontend/src/app/pages/login-page/login-page.component.ts
+++ b/src/digitalIdentity-frontend/src/app/pages/login-page/login-page.component.ts
@@ -1,7 +1,6 @@
 import { Component, isDevMode, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { InformationPopUpComponent } from '../../shared/pop-up/information-pop-up/information-pop-up.component';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { BackendHttpService } from 'src/app/services/backend-http-service/backend-http-service.service';
 import { ForgotPasswordPopUpComponent } from 'src/app/shared/pop-up/forgot-password-pop-up/forgot-password-pop-up.component';
@@ -57,16 +56,6 @@ export class LoginPageComponent implements OnInit {
         this.router.navigateByUrl(`/`);
       });
     }
-  }
-
-  //opens a PopUp window of class InformationPopUpComponent
-  openDialog(header: string, text: string) {
-    this.dialogRef.open(InformationPopUpComponent, {
-      data: {
-        header: header,
-        text: text,
-      },
-    });
   }
 
   openForgotPassword() {

--- a/src/digitalIdentity-frontend/src/app/pages/schema/create-schema-page/create-schema-page.component.ts
+++ b/src/digitalIdentity-frontend/src/app/pages/schema/create-schema-page/create-schema-page.component.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { InformationPopUpComponent } from 'src/app/shared/pop-up/information-pop-up/information-pop-up.component';
 import { BackendHttpService } from 'src/app/services/backend-http-service/backend-http-service.service';
 
 export interface attribute {
@@ -281,15 +280,5 @@ export class CreateSchemaPageComponent implements OnInit {
     params = params.append('attributes', s);
 
     return params;
-  }
-
-  //opens a PopUp window of class InformationPopUpComponent
-  openDialog(header: string, text: string) {
-    this.dialogRef.open(InformationPopUpComponent, {
-      data: {
-        header: header,
-        text: text,
-      },
-    });
   }
 }

--- a/src/digitalIdentity-frontend/src/app/services/backend-http-service/backend-http-service.service.ts
+++ b/src/digitalIdentity-frontend/src/app/services/backend-http-service/backend-http-service.service.ts
@@ -8,11 +8,10 @@ import {
 import { Injectable, isDevMode } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 import { catchError, Observable, of, timeout } from 'rxjs';
-import { InformationPopUpComponent } from 'src/app/shared/pop-up/information-pop-up/information-pop-up.component';
 import { environment } from 'src/environments/environment';
 import { lastValueFrom } from 'rxjs';
+import { ErrorMessageService } from '../error-message-service/error-message.service';
 @Injectable({
   providedIn: 'root',
 })
@@ -23,8 +22,7 @@ export class BackendHttpService {
   constructor(
     private http: HttpClient,
     private router: Router,
-    private dialogRef: MatDialog,
-    private cookieService: CookieService
+    private errorMessageService: ErrorMessageService,
   ) {}
 
   async postRequest(
@@ -66,13 +64,7 @@ export class BackendHttpService {
               );
             }
             const error = <HttpErrorResponse>(<any>response);
-
-            this.dialogRef.open(InformationPopUpComponent, {
-              data: {
-                header: 'Process failed',
-                text: 'Error ' + error.status + ' \n' + error.error,
-              },
-            });
+            this.errorMessageService.openHttpErrorDialog(error);
             reject(response);
           }
         },
@@ -86,12 +78,7 @@ export class BackendHttpService {
             }
           }
 
-          this.dialogRef.open(InformationPopUpComponent, {
-            data: {
-              header: 'Process failed',
-              text: 'Error ' + error.status + ' \n' + error.error,
-            },
-          });
+          this.errorMessageService.openHttpErrorDialog(error);
           reject(error);
         },
       })
@@ -132,12 +119,7 @@ export class BackendHttpService {
             }
             const error = <HttpErrorResponse>(<any>response);
 
-            this.dialogRef.open(InformationPopUpComponent, {
-              data: {
-                header: 'Process failed',
-                text: 'Error ' + response.status + ' \n' + error.error,
-              },
-            });
+            this.errorMessageService.openHttpErrorDialog(error);
             reject(response);
           }
         },
@@ -151,12 +133,7 @@ export class BackendHttpService {
             }
           }
 
-          this.dialogRef.open(InformationPopUpComponent, {
-            data: {
-              header: 'Process failed',
-              text: 'Error ' + error.status + ' \n' + error.error,
-            },
-          });
+          this.errorMessageService.openHttpErrorDialog(error);
           reject(error);
         },
       })
@@ -184,13 +161,13 @@ export class BackendHttpService {
             return callback && callback();
           }
         },
-        error: () => {
+        error: (error) => {
           this.authenticated = false;
-          this.dialogRef.open(InformationPopUpComponent, {
-            data: {
-              header: 'Login not successful!',
-            },
-          });
+          if (error.status == 401) {
+            this.errorMessageService.openCustomErrorDialog("Email or password incorrect.", "Login not successful!");
+          } else {
+            this.errorMessageService.openHttpErrorDialog(error);
+          }
         },
       });
   }

--- a/src/digitalIdentity-frontend/src/app/services/error-message-service/error-message.service.spec.ts
+++ b/src/digitalIdentity-frontend/src/app/services/error-message-service/error-message.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ErrorMessageService } from './error-message.service';
+
+describe('ErrorMessageService', () => {
+  let service: ErrorMessageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ErrorMessageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/digitalIdentity-frontend/src/app/services/error-message-service/error-message.service.ts
+++ b/src/digitalIdentity-frontend/src/app/services/error-message-service/error-message.service.ts
@@ -4,33 +4,34 @@ import { MatDialog } from '@angular/material/dialog';
 import { InformationPopUpComponent } from 'src/app/shared/pop-up/information-pop-up/information-pop-up.component';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ErrorMessageService {
+  private dialogOpen = false;
 
-  private dialogOpen = false
-
-  constructor(private matDialog: MatDialog) { }
+  constructor(private matDialog: MatDialog) {}
 
   openHttpErrorDialog(error: HttpErrorResponse) {
-
-    
     let data = {
       header: 'Process failed!',
       text: 'Error ' + error.status + ' \n' + error.error,
     };
-    
+
     if (error.status == 401) {
       data = {
         header: 'Login session expired (401)',
         text: 'Please log in to your account',
       };
     }
-    
+
     if (error.status >= 500) {
       data = {
         header: 'Internal Error (' + error.status + ')',
-        text: 'The server isn\'t configured right, is unavailable at the moment or a connected service isn\'t working right. This error message could help:\n\n\n' + error.message + '\n\n' + error.error,
+        text:
+          "The server isn't configured correctly, is unavailable at the moment or a connected service doesn't work properly. This error message could help:\n\n\n" +
+          error.message +
+          '\n\n' +
+          error.error,
       };
       if (typeof error.error === 'string' || error.error instanceof String) {
         if (error.error.length < 55) {
@@ -39,24 +40,25 @@ export class ErrorMessageService {
         }
       }
 
-      if (data.text.includes("Error occurred while trying to proxy:")) {
-        data.header = "Backend is not reachable.";
-        data.text = "Please contact your server administrator!\nIs the backend running? Is the backend reachable? Are the proxy settings correct?";
+      if (data.text.includes('Error occurred while trying to proxy:')) {
+        data.header = 'Backend is not reachable.';
+        data.text =
+          'Please contact your server administrator!\nIs the backend running? Is the backend reachable? Are the proxy settings correct?';
       }
     }
-    
+
     if (error.status == undefined) {
       data = {
         header: 'Internal Error',
-        text: 'The server isn\'t configured right or is unavailable at the moment.',
+        text: "The server isn't configured correctly or is unavailable at the moment.",
       };
     }
-    
+
     this.openDialog(data);
   }
-  
+
   openCustomErrorDialog(text = ``, header = `Process failed!`) {
-    this.openDialog( {
+    this.openDialog({
       header: header,
       text: text,
     });
@@ -64,7 +66,9 @@ export class ErrorMessageService {
 
   private openDialog(data: any) {
     if (this.dialogOpen) {
-      console.log("Another message should be displayed, but is rejected because another error message is still open. It will be displayed here:");
+      console.log(
+        'Another message should be displayed, but is rejected because another error message is still open. It will be displayed here: '
+      );
       console.log(data);
       return;
     }
@@ -75,7 +79,6 @@ export class ErrorMessageService {
     });
     this.matDialog.afterAllClosed.subscribe(() => {
       this.dialogOpen = false;
-    })
+    });
   }
-
 }

--- a/src/digitalIdentity-frontend/src/app/services/error-message-service/error-message.service.ts
+++ b/src/digitalIdentity-frontend/src/app/services/error-message-service/error-message.service.ts
@@ -1,0 +1,81 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { InformationPopUpComponent } from 'src/app/shared/pop-up/information-pop-up/information-pop-up.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ErrorMessageService {
+
+  private dialogOpen = false
+
+  constructor(private matDialog: MatDialog) { }
+
+  openHttpErrorDialog(error: HttpErrorResponse) {
+
+    
+    let data = {
+      header: 'Process failed!',
+      text: 'Error ' + error.status + ' \n' + error.error,
+    };
+    
+    if (error.status == 401) {
+      data = {
+        header: 'Login session expired (401)',
+        text: 'Please log in to your account',
+      };
+    }
+    
+    if (error.status >= 500) {
+      data = {
+        header: 'Internal Error (' + error.status + ')',
+        text: 'The server isn\'t configured right, is unavailable at the moment or a connected service isn\'t working right. This error message could help:\n\n\n' + error.message + '\n\n' + error.error,
+      };
+      if (typeof error.error === 'string' || error.error instanceof String) {
+        if (error.error.length < 55) {
+          data.header = String(error.error);
+          data.text = '';
+        }
+      }
+
+      if (data.text.includes("Error occurred while trying to proxy:")) {
+        data.header = "Backend is not reachable.";
+        data.text = "Please contact your server administrator!\nIs the backend running? Is the backend reachable? Are the proxy settings correct?";
+      }
+    }
+    
+    if (error.status == undefined) {
+      data = {
+        header: 'Internal Error',
+        text: 'The server isn\'t configured right or is unavailable at the moment.',
+      };
+    }
+    
+    this.openDialog(data);
+  }
+  
+  openCustomErrorDialog(text = ``, header = `Process failed!`) {
+    this.openDialog( {
+      header: header,
+      text: text,
+    });
+  }
+
+  private openDialog(data: any) {
+    if (this.dialogOpen) {
+      console.log("Another message should be displayed, but is rejected because another error message is still open. It will be displayed here:");
+      console.log(data);
+      return;
+    }
+
+    this.dialogOpen = true;
+    this.matDialog.open(InformationPopUpComponent, {
+      data: data,
+    });
+    this.matDialog.afterAllClosed.subscribe(() => {
+      this.dialogOpen = false;
+    })
+  }
+
+}

--- a/src/digitalIdentity-frontend/src/app/shared/pop-up/edit-window-pop-up/edit-window-pop-up.component.ts
+++ b/src/digitalIdentity-frontend/src/app/shared/pop-up/edit-window-pop-up/edit-window-pop-up.component.ts
@@ -74,6 +74,9 @@ export class EditWindowPopUpComponent implements OnInit {
   }
 
   init() {
+    if (this.id == undefined) {
+      return;
+    }
     const params = new HttpParams().append('id', Number(this.id));
     this.HttpService.getRequest(
       'Load DI data',


### PR DESCRIPTION
Signed-off-by: Jean28518 <jean-frederic.vog.vogelbacher@fau.de>

Wenn ich beispielsweise ein neues Schema mit unerlaubten Zeichen erstellen will, kommt nun aktuell die angepasste Fehlermeldung: 

![grafik](https://user-images.githubusercontent.com/39700889/180603376-9209157f-f733-4b3b-bed3-92c1063bd2c5.png)


Möchte ich als User allerdings wissen, warum wirklich das Schema nicht erstellt wurde: Müsste ich im Backend das handleResponse() umbauen, weil es nämlich bei Fehlercodes, die eigentliche message vom Lissi Agent löscht, in dem es nur null zurück gibt. Wollen wir also mehr Info, warum das seitens des Lissi Agent nicht geklappt hat, dem User anzeigen, müssten wie überall das handle Response bearbeiten.


Ist bspw. unser Server nicht erreichbar, wird natürlich eine andere Fehlermeldung, als "Could not create a schema" angezeigt... Habe das nicht hartgecodet, ist dynamisch vom Server.