### PR TITLE
fixed bug in stepper 

### DIFF
--- a/src/digitalIdentity-frontend/src/app/pages/proof-templ/create-proof-template/create-proof-templ/cpt-step3/cpt-step3.component.html
+++ b/src/digitalIdentity-frontend/src/app/pages/proof-templ/create-proof-template/create-proof-templ/cpt-step3/cpt-step3.component.html
@@ -10,7 +10,7 @@
   >
     Issue credential using data provided within this proof.
   </mat-checkbox>
-  <p *ngIf="this.autoIssueCredential_disabled()">
+  <p *ngIf="this.selectedCredDefs.length != 1">
     <mat-icon [ngStyle]="{ color: 'orange', opacity: '1' }">warning</mat-icon>
     Currently only supported if and only if one credential definition is
     selected. You have <b>{{ this.selectedCredDefs.length }}</b> selected.

--- a/src/digitalIdentity-frontend/src/app/pages/proof-templ/create-proof-template/create-proof-templ/cpt-step3/cpt-step3.component.ts
+++ b/src/digitalIdentity-frontend/src/app/pages/proof-templ/create-proof-template/create-proof-templ/cpt-step3/cpt-step3.component.ts
@@ -15,10 +15,14 @@ export class CptStep3Component implements OnInit {
   ngOnInit(): void {}
 
   completed(): boolean {
-    return true;
+    // returns true if checkbox one cred def is selected or
+    // if the automatic aciton cred issue is not selected
+    return this.selectedCredDefs.length == 1 || !this.autoIssueCredential;
   }
 
   autoIssueCredential_disabled(): boolean {
-    return this.selectedCredDefs.length != 1;
+    // enables the autoIssue checkbox, if it is checked or there is only one cred def selected
+    let enabled = this.autoIssueCredential || this.selectedCredDefs.length == 1;
+    return !enabled;
   }
 }


### PR DESCRIPTION
Previously, you could achieve an illegal state by completing step1-3 and checking only one Cred Def. Then you could check "autoIssueCred" in step3 and unlock step4. If you now went back to step 2, you could select more than one Cred Def. The checkbox in step 3 remained set. 

Signed-off-by: Karol Bakas <karol.bakas@fau.de>